### PR TITLE
feat: add maxLength limits to Input and TextArea

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2024-05-15 - Unbounded Input Size Limits (DoS Risk)
-**Vulnerability:** Input fields (`Input` and `TextArea`) did not enforce maximum length limits natively, allowing unbounded user input size.
-**Learning:** This is an application-level DoS vector, where unusually large inputs can cause excessive memory allocation and potentially stall rendering or degrade system performance over time.
-**Prevention:** All user text inputs should impose a default reasonable `maxLength` attribute directly on the underlying HTML elements. Next time, make sure input wrappers default to `maxLength=255` for single lines and `maxLength=1000` for textareas unless explicitly overridden.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Unbounded Input Size Limits (DoS Risk)
+**Vulnerability:** Input fields (`Input` and `TextArea`) did not enforce maximum length limits natively, allowing unbounded user input size.
+**Learning:** This is an application-level DoS vector, where unusually large inputs can cause excessive memory allocation and potentially stall rendering or degrade system performance over time.
+**Prevention:** All user text inputs should impose a default reasonable `maxLength` attribute directly on the underlying HTML elements. Next time, make sure input wrappers default to `maxLength=255` for single lines and `maxLength=1000` for textareas unless explicitly overridden.

--- a/src/atoms/input/Input.component.tsx
+++ b/src/atoms/input/Input.component.tsx
@@ -14,14 +14,23 @@ export interface InputProps {
    * The label for the input
    */
   label?: string;
+  /**
+   * The maximum length of the input (prevent unbounded inputs)
+   */
+  maxLength?: number;
+  /**
+   * The type of input (e.g., text, password)
+   */
+  type?: string;
 }
 
-export function Input ({ value, onChange, label }: InputProps) {
+export function Input ({ value, onChange, label, maxLength = 255, type = 'text' }: InputProps) {
   return (
     <FormFieldWrapper label={label} htmlFor="input">
       <input
         id="input"
-        type="text"
+        type={type}
+        maxLength={maxLength}
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
         className="border-[1px] border-secondary rounded-md"

--- a/src/atoms/input/Input.component.tsx
+++ b/src/atoms/input/Input.component.tsx
@@ -14,13 +14,7 @@ export interface InputProps {
    * The label for the input
    */
   label?: string;
-  /**
-   * The maximum length of the input (prevent unbounded inputs)
-   */
   maxLength?: number;
-  /**
-   * The type of input (e.g., text, password)
-   */
   type?: string;
 }
 

--- a/src/atoms/input/__snapshots__/Input.stories.tsx.snap
+++ b/src/atoms/input/__snapshots__/Input.stories.tsx.snap
@@ -9,6 +9,7 @@ exports[`Atoms/Input All smoke-test 2`] = `
   </label>
   <input id="input"
          type="text"
+         maxlength="255"
          class="border-[1px] border-secondary rounded-md"
          value
          style

--- a/src/atoms/textArea/TextArea.component.tsx
+++ b/src/atoms/textArea/TextArea.component.tsx
@@ -14,13 +14,18 @@ export interface TextAreaProps {
    * The label for the input
    */
   label?: string;
+  /**
+   * The maximum length of the input (prevent unbounded inputs)
+   */
+  maxLength?: number;
 }
 
-export function TextArea ({ value, onChange, label }: TextAreaProps) {
+export function TextArea ({ value, onChange, label, maxLength = 1000 }: TextAreaProps) {
   return (
     <FormFieldWrapper label={label} htmlFor="textarea">
       <textarea
         id="textarea"
+        maxLength={maxLength}
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
         className="border-[1px] border-secondary rounded-md resize-none"

--- a/src/atoms/textArea/TextArea.component.tsx
+++ b/src/atoms/textArea/TextArea.component.tsx
@@ -14,9 +14,6 @@ export interface TextAreaProps {
    * The label for the input
    */
   label?: string;
-  /**
-   * The maximum length of the input (prevent unbounded inputs)
-   */
   maxLength?: number;
 }
 

--- a/src/atoms/textArea/__snapshots__/TextArea.stories.tsx.snap
+++ b/src/atoms/textArea/__snapshots__/TextArea.stories.tsx.snap
@@ -8,6 +8,7 @@ exports[`Atoms/Text Area All smoke-test 2`] = `
     Enter text here
   </label>
   <textarea id="textarea"
+            maxlength="1000"
             class="border-[1px] border-secondary rounded-md resize-none"
             style
   >


### PR DESCRIPTION
- Add `maxLength` (default 255) and `type` (default text) to `Input` component.
- Add `maxLength` (default 1000) to `TextArea` component.
- Update snapshot tests to reflect the new DOM attributes (`maxlength="255"` and `maxlength="1000"`).
- Document learning in `.jules/sentinel.md`.

This prevents unbounded input sizes which can be a DoS vector.

---
*PR created automatically by Jules for task [9107053895071290601](https://jules.google.com/task/9107053895071290601) started by @JDoro*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input fields now support customizable input types (text, email, password, etc.)
  * Character length limits now enforced on input fields (default: 255 characters) and text areas (default: 1000 characters)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->